### PR TITLE
Add JSON declaration fields

### DIFF
--- a/ActiveStandard/callExample.json
+++ b/ActiveStandard/callExample.json
@@ -1,4 +1,7 @@
 {
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "http://finos.org/schemas/callmetadata.json",
+	"title": "Call Metadata Standard",
 	"callDetailRecord": {
 		"type": "object",
 		"description": "Meta data supporting dialtone, ringdown, and shoutdown calls",


### PR DESCRIPTION
Add declaration fields on JSON Schema file for identification and
validation:

* JSON Schema version which is useful for schema validation.
* Unique identifier for FINOS call metadata standard.
* Title to describe the purpose of the schema.