### PR TITLE
Use built-in date-time on date time fields

### DIFF
--- a/ActiveStandard/callExample.json
+++ b/ActiveStandard/callExample.json
@@ -23,6 +23,7 @@
 			},
 			"callStartTime": {
 				"type": "string",
+				"format": "date-time",
 				"description": "Start time of the call in ISO 8601 UTC time time format",
 				"example": "2016-06-18T07:50:30Z"
 			},
@@ -123,11 +124,13 @@
 					},
 					"startTime": {
 						"type": "string",
+						"format": "date-time",
 						"example": "2016-06-18T07:50:30Z",
 						"description": "The time when the call started"
 					},
 					"stopTime": {
 						"type": "string",
+						"format": "date-time",
 						"example": "2016-06-18T08:05:15Z",
 						"description": "The time when the call terminated"
 					},


### PR DESCRIPTION
Use built-in date-time(https://json-schema.org/understanding-json-schema/reference/string.html?highlight=date%20time) on date time fields.

This is useful for validations.